### PR TITLE
Maintain site source in Markdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+SRC = $(shell find . -type f -name '*.md')
+
+.PHONEY: all clean
+
+all: $(SRC:.md=.html)
+
+clean:
+	rm -f $(SRC:.md=.html)
+
+%.html: %.md
+	pandoc -f markdown -t html -H _header.html -s -o $(@) $<

--- a/_header.html
+++ b/_header.html
@@ -1,0 +1,11 @@
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style type="text/css">
+  body {
+    max-width: 52em;
+    margin: 1em auto;
+    padding: 0 1em;
+    color: #333;
+    line-height: 1.4em;
+    font-size: 1em;
+  }
+</style>

--- a/index.html
+++ b/index.html
@@ -1,12 +1,31 @@
-<!DOCTYPE html PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
-   <HEAD>
-      <TITLE>
-         Sup? 
-      </TITLE>
-   </HEAD>
-<BODY>
-   <H1>Hi</H1>
-   <P>This is a test for jeffburro.ws</P> 
-</BODY>
-</HTML>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="Content-Style-Type" content="text/css" />
+  <meta name="generator" content="pandoc" />
+  <meta name="author" content="Author?" />
+  <title>Title!</title>
+  <style type="text/css">code{white-space: pre;}</style>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style type="text/css">
+    body {
+      max-width: 52em;
+      margin: 1em auto;
+      padding: 0 1em;
+      color: #333;
+      line-height: 1.4em;
+      font-size: 1em;
+    }
+  </style>
+</head>
+<body>
+<div id="header">
+<h1 class="title">Title!</h1>
+<h2 class="author">Author?</h2>
+<h3 class="date">Date.</h3>
+</div>
+<h2 id="hi">Hi</h2>
+<p>This is a test for <a href="http://jeffburro.ws">jeffburro.ws</a>.</p>
+</body>
+</html>

--- a/index.md
+++ b/index.md
@@ -1,0 +1,7 @@
+% Title!
+% Author?
+% Date.
+
+## Hi
+
+This is a test for [jeffburro.ws](http://jeffburro.ws).


### PR DESCRIPTION
The site is built using pandoc via make:

```
$ make
pandoc -f markdown -t html -H _header.html -o index.html index.md
```

This detects each `.md` file and uses pandoc to generate an `.html`
version of it.
